### PR TITLE
Update bsock.h

### DIFF
--- a/bsock.h
+++ b/bsock.h
@@ -24,7 +24,7 @@
 
 #include "dsock.h"
 
-const void *bsock_type;
+extern const void *bsock_type;
 
 struct bsock_vfs {
     int (*bsendv)(struct bsock_vfs *vfs, const struct iovec *iov, size_t iovlen,


### PR DESCRIPTION
Avoid linker conflicts:

```
duplicate symbol _msock_type in:
    .libs/libdsock_la-crlf.o
    .libs/libdsock_la-udp.o
duplicate symbol _bsock_type in:
    .libs/libdsock_la-blog.o
    .libs/libdsock_la-unix.o
ld: 15 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [libdsock.la] Error 1
```