### PR TITLE
Fix fdget to always return the number of bytes read

### DIFF
--- a/fd.c
+++ b/fd.c
@@ -132,13 +132,13 @@ static ssize_t fdget(int s, struct iovec *iov, size_t iovlen, int block,
         hdr.msg_iov = vec;
         hdr.msg_iovlen = veclen;
         ssize_t sz = recvmsg(s, &hdr, 0);
-        if(dsock_fast(sz == len)) return len;
+        pos += sz;
+        if(dsock_fast(sz == len)) return pos;
         if(dsock_slow(sz == 0)) {errno = ECONNRESET; return -1;}
         if(dsock_slow(sz < 0 && errno != EWOULDBLOCK && errno != EAGAIN))
             return -1;
         if(dsock_fast(sz > 0)) {
             if(!block) return sz;
-            pos += sz;
             len -= sz;
         }
         int rc = fdin(s, deadline);

--- a/fd.c
+++ b/fd.c
@@ -132,13 +132,13 @@ static ssize_t fdget(int s, struct iovec *iov, size_t iovlen, int block,
         hdr.msg_iov = vec;
         hdr.msg_iovlen = veclen;
         ssize_t sz = recvmsg(s, &hdr, 0);
-        pos += sz;
-        if(dsock_fast(sz == len)) return pos;
+        if(dsock_fast(sz == len)) return pos + sz;
         if(dsock_slow(sz == 0)) {errno = ECONNRESET; return -1;}
         if(dsock_slow(sz < 0 && errno != EWOULDBLOCK && errno != EAGAIN))
             return -1;
         if(dsock_fast(sz > 0)) {
             if(!block) return sz;
+            pos += sz;
             len -= sz;
         }
         int rc = fdin(s, deadline);


### PR DESCRIPTION
Fixes #15 by using the position within the buffer which is always equal to the length of bytes written.