### PR TITLE
Fix incorrect http header field-value processing

### DIFF
--- a/http.c
+++ b/http.c
@@ -222,13 +222,18 @@ int http_sendfield(int s, const char *name, const char *value,
     struct http_sock *obj = hquery(s, http_type);
     if(dsock_slow(!obj)) return -1;
     /* TODO: Check whether name contains only valid characters! */
+    if (strpbrk(name, "(),/:;<=>?@[\\]{}\" \t") != NULL) {errno = EPROTO; return -1;}
+    if (strlen(value) == 0) {errno = EPROTO; return -1;}
     struct iovec iov[3];
     iov[0].iov_base = (void*)name;
     iov[0].iov_len = strlen(name);
     iov[1].iov_base = (void*)": ";
     iov[1].iov_len = 2;
-    iov[2].iov_base = (void*)value;
-    iov[2].iov_len = strlen(value);
+    const char *start = dsock_lstrip(value, ' ');
+    const char *end = dsock_rstrip(start, ' ');
+    dsock_assert(start < end);
+    iov[2].iov_base = (void*)start;
+    iov[2].iov_len = end - start;
     return msendv(obj->s, iov, 3, deadline);
 }
 
@@ -258,8 +263,7 @@ int http_recvfield(int s, char *name, size_t namelen,
     while(obj->rxbuf[pos] == ' ') ++pos;
     /* Value. */
     start = pos;
-    pos = (size_t) sz;
-    while(pos >= start && obj->rxbuf[pos] == ' ') --pos;
+    pos = dsock_rstrip(obj->rxbuf + sz, ' ') - obj->rxbuf;
     if(dsock_slow(pos - start > valuelen - 1)) {errno = EMSGSIZE; return -1;}
     memcpy(value, obj->rxbuf + start, pos - start);
     value[pos - start] = 0;

--- a/http.c
+++ b/http.c
@@ -258,7 +258,8 @@ int http_recvfield(int s, char *name, size_t namelen,
     while(obj->rxbuf[pos] == ' ') ++pos;
     /* Value. */
     start = pos;
-    while(obj->rxbuf[pos] != 0 && obj->rxbuf[pos] != ' ') ++pos;
+    pos = (size_t) sz;
+    while(pos >= start && obj->rxbuf[pos] == ' ') --pos;
     if(dsock_slow(pos - start > valuelen - 1)) {errno = EMSGSIZE; return -1;}
     memcpy(value, obj->rxbuf + start, pos - start);
     value[pos - start] = 0;

--- a/tests/http.c
+++ b/tests/http.c
@@ -41,6 +41,8 @@ int main() {
     assert(rc == 0);
     rc = http_sendfield(s0, "baz", "quux", -1);
     assert(rc == 0);
+    rc = http_sendfield(s0, "Date", "Tue, 15 Nov 1994 08:12:31 GMT", -1);
+    assert(rc == 0);
     rc = http_done(s0, -1);
     assert(rc == 0);
     /* Receive request. */
@@ -51,7 +53,7 @@ int main() {
     assert(strcmp(cmd, "GET") == 0);
     assert(strcmp(url, "/a/b/c") == 0);
     char name[16];
-    char value[16];
+    char value[32];
     rc = http_recvfield(s1, name, sizeof(name), value, sizeof(value), -1);
     assert(rc == 0);
     assert(strcmp(name, "foo") == 0);
@@ -60,6 +62,10 @@ int main() {
     assert(rc == 0);
     assert(strcmp(name, "baz") == 0);
     assert(strcmp(value, "quux") == 0);
+    rc = http_recvfield(s1, name, sizeof(name), value, sizeof(value), -1);
+    assert(rc == 0);
+    assert(strcmp(name, "Date") == 0);
+    assert(strcmp(value, "Tue, 15 Nov 1994 08:12:31 GMT") == 0);
     rc = http_recvfield(s1, name, sizeof(name), value, sizeof(value), -1);
     assert(rc < 0 && errno == EPIPE);
     /* Send response. */

--- a/utils.c
+++ b/utils.c
@@ -104,3 +104,14 @@ int dsock_random(uint8_t *buf, size_t len, int64_t deadline) {
     return 0;
 }
 
+const char *dsock_lstrip(const char *string, char delim) {
+    const char *pos = string;
+    while(*pos && *pos == delim) ++pos;
+    return pos;
+}
+
+const char *dsock_rstrip(const char *string, char delim) {
+    const char *end = string + strlen(string) - 1;
+    while(end > string && *end == delim) --end;
+    return ++end;
+}

--- a/utils.h
+++ b/utils.h
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #define dsock_concat(x,y) x##y
 
@@ -78,6 +79,12 @@ uint64_t dsock_getll(const uint8_t *buf);
 void dsock_putll(uint8_t *buf, uint64_t val);
 
 int dsock_random(uint8_t *buf, size_t len, int64_t deadline);
+
+/* Returns a pointer to the first character in string that is not delim */
+const char *dsock_lstrip(const char *string, char delim);
+
+/* Returns a pointer after the last character in string that is not delim */
+const char *dsock_rstrip(const char *string, char delim);
 
 #endif
 


### PR DESCRIPTION
field-values can contain whitespace, see: https://tools.ietf.org/html/rfc7231#section-7.1.1.2 for an example.
Add test case to check this.

Without looking to deep into the other code, I'd estimate that there might be more subtle bugs in the http processing functions. That opens the question if such code should not be taken from other, already well tested libraries instead.