### PR TITLE
freebsd compatibility for S_IWUSR/S_IRUSR

### DIFF
--- a/tls/compat/openssl.c
+++ b/tls/compat/openssl.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 int SSL_CTX_load_verify_mem(SSL_CTX *ctx, void *buf, int len)
 {


### PR DESCRIPTION
This header is needed for tls compat on FreeBSD.